### PR TITLE
fix: commit files w/ input token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,7 @@ runs:
       id: check
       shell: bash -leo pipefail {0}
       run: |
+        # skip if PR already exists
         if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
           if [[ "${HAS_RELOCK_SLUG}" == "false" || "${COMMENT_IS_PR}" == "false" ]]; then
             res="true"
@@ -117,6 +118,7 @@ runs:
         && startsWith(github.event.comment.body, '/relock-conda')
       shell: bash -leo pipefail {0}
       run: |
+        # react to issue comment
         gh api \
           --method POST \
           -H "Accept: application/vnd.github+json" \
@@ -149,6 +151,7 @@ runs:
         && startsWith(github.event.comment.body, '/relock-conda')
       shell: bash -leo pipefail {0}
       run: |
+        # checkout PR if running on an issue
         gh pr checkout ${{ github.event.issue.number }}
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -158,6 +161,7 @@ runs:
       if: ${{ steps.check.outputs.skip != 'true' }}
       shell: bash -leo pipefail {0}
       run: |
+        # relock
         echo "::group::relock"
         python ${{ github.action_path }}/relock.py \
           --environment-file='${{ inputs.environment-file }}' \
@@ -187,11 +191,11 @@ runs:
         )
       shell: bash -leo pipefail {0}
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add ${{ inputs.lock-file }}
-        git commit -m "relock w/ conda-lock"
-        git push
+        # commit changes
+        python ${{ github.action_path }}/commit_lockfile.py \
+          --lock-file='${{ inputs.lock-file }}'
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
 
     - name: open PR
       id: pr
@@ -224,15 +228,18 @@ runs:
         && inputs.action == 'pr'
         && github.event_name != 'issue_comment'
       shell: bash -leo pipefail {0}
-      run: gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+      run: |
+        # automerge
+        gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
       env:
         GH_TOKEN: ${{ inputs.github-token }}
 
-    - name: set output
+    - name: set outputs
       id: set-output
       if: always()
       shell: bash -leo pipefail {0}
       run: |
+        # set outputs
         res=""
 
         # if we skipped, we did not relock

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -33,6 +33,11 @@ def main(
 ):
     repo_owner, repo_name = _get_repo_owner_and_name()
     branch = _get_current_branch()
+    print(
+        f"Updating '{lock_file}' in '{repo_owner}/{repo_name}' on branch '{branch}'...",
+        flush=True,
+    )
+
     gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     repo = gh.get_repo(f"{repo_owner}/{repo_name}")
 
@@ -48,7 +53,7 @@ def main(
         branch=branch,
     )
     print(
-        f"Updated {lock_file} in {repo_owner}/{repo_name} on branch {branch} w/ commit {res['commit'].sha}",
+        f"Updated w/ commit {res['commit'].sha}",
         flush=True,
     )
 

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+
+import click
+import github
+
+
+def _get_repo_owner_and_name():
+    res = subprocess.run(
+        ["git", "remote", "get-url", "--push", "origin"],
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError("Could not get repo name")
+    parts = res.stdout.strip().split("/")
+    return parts[-2], parts[-1][: -len(".git")]
+
+
+def _get_current_branch():
+    res = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError("Could not get current branch")
+    return res.stdout.strip()
+
+
+@click.command()
+@click.option("--lock-file", required=True, type=click.Path())
+def main(
+    lock_file,
+):
+    repo_owner, repo_name = _get_repo_owner_and_name()
+    branch = _get_current_branch()
+    gh = github.Github(auth=github.Auth.Token(os.eviron["GH_TOKEN"]))
+    repo = gh.get_repo(f"{repo_owner}/{repo_name}")
+
+    contents = repo.get_contents(lock_file, ref=branch)
+    with open(lock_file, "r") as f:
+        new_lockfile_content = f.read()
+
+    res = repo.update_file(
+        contents.path,
+        "relock w/ conda-lock",
+        new_lockfile_content,
+        contents.sha,
+        branch=branch,
+    )
+    print(
+        f"Updated {lock_file} in {repo_owner}/{repo_name} on branch {branch} w/ commit {res['commit'].sha}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -7,6 +7,7 @@ import github
 
 def _get_repo_owner_and_name():
     subprocess.run(["git", "remote", "-v"])
+    subprocess.run(["git", "remote", "get-url", "--push", "origin"])
     res = subprocess.run(
         ["git", "remote", "get-url", "--push", "origin"],
         shell=True,

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -6,17 +6,22 @@ import github
 
 
 def _get_repo_owner_and_name():
-    subprocess.run(["git", "remote", "-v"])
-    subprocess.run(["git", "remote", "get-url", "--push", "origin"])
+    # for w/e reason, this sometimes returns a non-zero exit code
+    # even if it works
     res = subprocess.run(
         ["git", "remote", "get-url", "--push", "origin"],
         shell=True,
-        check=True,
         stdout=subprocess.PIPE,
         text=True,
     )
-    parts = res.stdout.strip().split("/")
-    return parts[-2], parts[-1][: -len(".git")]
+    output = res.stdout.strip()
+    if (
+        output.startswith("https://github.com") or output.startswith("git@github.com")
+    ) and output.endswith(".git"):
+        parts = res.stdout.strip().split("/")
+        return parts[-2], parts[-1][: -len(".git")]
+    else:
+        raise RuntimeError("Could not get repo owner and name:\n" + output)
 
 
 def _get_current_branch():

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -13,7 +13,9 @@ def _get_repo_owner_and_name():
         text=True,
     )
     parts = res.stdout.strip().split("/")
-    return parts[-2], parts[-1][: -len(".git")]
+    if parts[-1].endswith(".git"):
+        parts[-1] = parts[-1][: -len(".git")]
+    return parts[-2], parts[-1]
 
 
 def _get_current_branch():

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -13,7 +13,7 @@ def _get_repo_owner_and_name():
         text=True,
     )
     if res.returncode != 0:
-        raise RuntimeError("Could not get repo name")
+        raise RuntimeError("Could not get repo name:\n" + res.stderr)
     parts = res.stdout.strip().split("/")
     return parts[-2], parts[-1][: -len(".git")]
 
@@ -26,7 +26,7 @@ def _get_current_branch():
         text=True,
     )
     if res.returncode != 0:
-        raise RuntimeError("Could not get current branch")
+        raise RuntimeError("Could not get current branch:\n" + res.stderr)
     return res.stdout.strip()
 
 

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -6,28 +6,19 @@ import github
 
 
 def _get_repo_owner_and_name():
-    # for w/e reason, this sometimes returns a non-zero exit code
-    # even if it works
     res = subprocess.run(
         ["git", "remote", "get-url", "--push", "origin"],
-        shell=True,
+        check=True,
         stdout=subprocess.PIPE,
         text=True,
     )
-    output = res.stdout.strip()
-    if (
-        output.startswith("https://github.com") or output.startswith("git@github.com")
-    ) and output.endswith(".git"):
-        parts = res.stdout.strip().split("/")
-        return parts[-2], parts[-1][: -len(".git")]
-    else:
-        raise RuntimeError("Could not get repo owner and name:\n" + output)
+    parts = res.stdout.strip().split("/")
+    return parts[-2], parts[-1][: -len(".git")]
 
 
 def _get_current_branch():
     res = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        shell=True,
         check=True,
         stdout=subprocess.PIPE,
         text=True,

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -9,11 +9,10 @@ def _get_repo_owner_and_name():
     res = subprocess.run(
         ["git", "remote", "get-url", "--push", "origin"],
         shell=True,
-        capture_output=True,
+        check=True,
+        stdout=subprocess.PIPE,
         text=True,
     )
-    if res.returncode != 0:
-        raise RuntimeError("Could not get repo name:\n" + res.stderr)
     parts = res.stdout.strip().split("/")
     return parts[-2], parts[-1][: -len(".git")]
 
@@ -22,11 +21,10 @@ def _get_current_branch():
     res = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
         shell=True,
-        capture_output=True,
+        check=True,
+        stdout=subprocess.PIPE,
         text=True,
     )
-    if res.returncode != 0:
-        raise RuntimeError("Could not get current branch:\n" + res.stderr)
     return res.stdout.strip()
 
 

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -6,6 +6,7 @@ import github
 
 
 def _get_repo_owner_and_name():
+    subprocess.run(["git", "remote", "-v"])
     res = subprocess.run(
         ["git", "remote", "get-url", "--push", "origin"],
         shell=True,

--- a/commit_lockfile.py
+++ b/commit_lockfile.py
@@ -33,7 +33,7 @@ def main(
 ):
     repo_owner, repo_name = _get_repo_owner_and_name()
     branch = _get_current_branch()
-    gh = github.Github(auth=github.Auth.Token(os.eviron["GH_TOKEN"]))
+    gh = github.Github(auth=github.Auth.Token(os.environ["GH_TOKEN"]))
     repo = gh.get_repo(f"{repo_owner}/{repo_name}")
 
     contents = repo.get_contents(lock_file, ref=branch)


### PR DESCRIPTION
This PR commits the lock file w/ the input token. This will allow CI checks to run if people use an app or PAT token instead of the default GH token.